### PR TITLE
Newer method

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,14 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters: []
+formatter:
+require_paths: []
+plugins: []
+max_files: 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2 AS development
+FROM ruby:3.2 AS base
 
 # These build args are in your `.env` file, and they exist so that for
 # development the user in the container has the same UID and GID as you. 
@@ -26,17 +26,21 @@ USER app
 
 ENV BUNDLE_PATH /gems
 
-COPY --chown=${UID}:${GID} Gemfile* /app/
-
 WORKDIR /app
+
+CMD ["tail", "-f", "/dev/null"]
+
+FROM base AS development
+
+COPY --chown=${UID}:${GID} Gemfile /app/
 
 # cache mount for bundle install so running bundle install won't reinstall
 # everything
 RUN --mount=type=cache,target=/gems/bundle,uid=${UID},gid=${GID} \
   bundle install
 
-CMD ["tail", "-f", "/dev/null"]
-
-FROM development AS production
+FROM base AS production
 
 COPY --chown=${UID}:${GID} . /app
+
+RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-slim-bookworm AS development
+FROM ruby:3.2 AS development
 
 # These build args are in your `.env` file, and they exist so that for
 # development the user in the container has the same UID and GID as you. 
@@ -26,11 +26,17 @@ USER app
 
 ENV BUNDLE_PATH /gems
 
+COPY --chown=${UID}:${GID} Gemfile* /app/
+
 WORKDIR /app
+
+# cache mount for bundle install so running bundle install won't reinstall
+# everything
+RUN --mount=type=cache,target=/gems/bundle,uid=${UID},gid=${GID} \
+  bundle install
 
 CMD ["tail", "-f", "/dev/null"]
 
 FROM development AS production
 
 COPY --chown=${UID}:${GID} . /app
-RUN bundle  install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ruby:3.2 AS development
+FROM ruby:3.2-slim-bookworm AS development
 
-ARG UNAME=app
+# These build args are in your `.env` file, and they exist so that for
+# development the user in the container has the same UID and GID as you. 
 ARG UID=1000
 ARG GID=1000
 
@@ -10,11 +11,18 @@ ARG GID=1000
 
 RUN gem install bundler
 
-RUN groupadd -g ${GID} -o ${UNAME}
-RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+# Add the app group. Map it's GID to the build arg. -o means it's ok if it's a non-unique GID.
+RUN groupadd -g ${GID} -o app
+
+# Add the app user. Map its UID and GID to the build args. Create a /app home
+# directory for it. -o means it's ok if it's a non-unique GID. Set the shell to
+# bash. 
+RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash app
+
+#Make a gems directory and have it owned by the app user and group
 RUN mkdir -p /gems && chown ${UID}:${GID} /gems
 
-USER $UNAME
+USER app
 
 ENV BUNDLE_PATH /gems
 
@@ -26,4 +34,3 @@ FROM development AS production
 
 COPY --chown=${UID}:${GID} . /app
 RUN bundle  install
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+gem "marc"
+gem "rails"
+
 group :development do
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,10 @@
 source "https://rubygems.org"
 
-group :development, :test do
+group :development do
   gem "pry"
   gem "pry-byebug"
-end
-
-group :test do
+  gem "standard"
   gem "rspec"
   gem "simplecov"
   gem "simplecov-lcov"
-end
-
-group :development do
-  gem "standard"
 end

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ Run the setup script
 
 This will:
 
-* copy `env.example` to `.env` 
+* copy `env.example` to `.env` and in the env file sets the UID and GID to your values.
 * enable the precommit hook which wil lint the code before committing.  Uncomment
   those lines in `.git/hooks/precommit` to enable running tests.
 * build the docker image
-* install the gems
 
 The script does not overwrite `.env` or `/git/hooks/precommit`.
 

--- a/bundle_install.sh
+++ b/bundle_install.sh
@@ -1,0 +1,2 @@
+#This builds the gems and updates Gemfile.lock
+docker compose build && docker compose run --rm app bundle install

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,9 @@ services:
     build: 
       context: .
       target: development
+      args:
+        - UID=${UID}
+        - GID=${UID}
     volumes:
       - .:/app
       - gem_cache:/gems

--- a/compose.yml
+++ b/compose.yml
@@ -8,9 +8,5 @@ services:
         - GID=${UID}
     volumes:
       - .:/app
-      - gem_cache:/gems
     env_file:
       - .env
-        
-volumes:
-  gem_cache:

--- a/env.example
+++ b/env.example
@@ -1,1 +1,5 @@
+#Set these to your actual UID and GID
+UID=1000
+GID=1000
+
 SEKRET="aweflweif;wltgi5t13o5i"

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 #Set these to your actual UID and GID
-UID=1000
-GID=1000
+UID=YOUR_UID
+GID=YOUR_GID
 
 SEKRET="aweflweif;wltgi5t13o5i"

--- a/init.sh
+++ b/init.sh
@@ -3,6 +3,11 @@ if [ -f ".env" ]; then
 else
   echo "🌎 .env does not exist. Copying .env-example to .env"
   cp env.example .env
+  YOUR_UID=`id -u`
+  YOUR_GID=`id -g`
+  echo "🙂 Setting your UID ($YOUR_UID) and GID ($YOUR_UID) in .env"
+  sed -i s/YOUR_UID/$YOUR_UID/ .env
+  sed -i s/YOUR_GID/$YOUR_GID/ .env
 fi
 
 if [ -f ".git/hooks/pre-commit" ]; then
@@ -14,6 +19,3 @@ fi
 
 echo "🚢 Build docker images"
 docker compose build
-
-echo "📦 Installing Gems"
-docker compose run --rm app bundle


### PR DESCRIPTION
Part of this I like and part of this I don't like.

Part I like:

Set GID and UID on init and taking out the UNAME because we don't need it. This should fix the problem with users that don't have GID and UID = 1000

Part I don't like, using docker cache mount for bundle installing. The problem is that we need the Gemfile.lock and it gets generated in the container, but not on the host system, so we can't check it into version control without running bundle install twice. 